### PR TITLE
add new config API for use with SDK 5.14.0+, similar to 6.0

### DIFF
--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/LaunchDarkly.ServerSdk.SharedTests.csproj
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/LaunchDarkly.ServerSdk.SharedTests.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.ServerSdk" Version="5.6.4" />
+    <PackageReference Include="LaunchDarkly.ServerSdk" Version="5.14.0-alpha.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 </Project>

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/LaunchDarkly.ServerSdk.SharedTests.csproj
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/LaunchDarkly.ServerSdk.SharedTests.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.ServerSdk" Version="5.14.0-alpha.1" />
+    <PackageReference Include="LaunchDarkly.ServerSdk" Version="5.14.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 </Project>

--- a/src/LaunchDarkly.ServerSdk.Consul/ConsulComponents.cs
+++ b/src/LaunchDarkly.ServerSdk.Consul/ConsulComponents.cs
@@ -1,34 +1,19 @@
-﻿namespace LaunchDarkly.Client.Consul
+﻿using System;
+
+namespace LaunchDarkly.Client.Consul
 {
     /// <summary>
-    /// Entry point for using the Consul feature store with the LaunchDarkly SDK.
-    /// 
-    /// For more details about how and why you can use a persistent feature store, see:
-    /// https://docs.launchdarkly.com/v2.0/docs/using-a-persistent-feature-store
-    /// 
-    /// To use the Consul feature store with the LaunchDarkly client, you will first obtain a
-    /// builder by calling <see cref="ConsulComponents.ConsulFeatureStore()"/>,
-    /// then optionally modify its properties, and then include it in your client configuration.
-    /// For example:
-    /// 
-    /// <code>
-    /// using LaunchDarkly.Client;
-    /// using LaunchDarkly.Client.Consul;
-    /// 
-    /// var store = ConsulComponents.ConsulFeatureStore()
-    ///     .WithCaching(FeatureStoreCaching.Enabled.WithTtlSeconds(30));
-    /// var config = Configuration.Default("my-sdk-key")
-    ///     .WithFeatureStoreFactory(store);
-    /// </code>
-    /// 
-    /// The default Consul configuration uses an address of <code>localhost:8500</code>. To customize any
-    /// properties of Consul, you can use the methods on <see cref="ConsulFeatureStoreBuilder"/>.
-    /// 
-    /// If you are using the same Consul host as a feature store for multiple LaunchDarkly
-    /// environments, use the <see cref="ConsulFeatureStoreBuilder.WithPrefix(string)"/>
-    /// option and choose a different prefix string for each, so they will not interfere with each
-    /// other's data. 
+    /// Obsolete entry point for the Consul integration.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This class is retained in version 1.1 of the library for backward compatibility. For the new
+    /// preferred way to configure the Consul integration, see <see cref="LaunchDarkly.Client.Integrations.Consul"/>.
+    /// Updating to the latter now will make it easier to adopt version 6.0 of the LaunchDarkly .NET SDK, since
+    /// an identical API is used there (except for the base namespace).
+    /// </para>
+    /// </remarks>
+    [Obsolete("Use LaunchDarkly.Client.Integrations.Consul")]
     public abstract class ConsulComponents
     {
         /// <summary>

--- a/src/LaunchDarkly.ServerSdk.Consul/ConsulFeatureStoreBuilder.cs
+++ b/src/LaunchDarkly.ServerSdk.Consul/ConsulFeatureStoreBuilder.cs
@@ -6,16 +6,17 @@ using LaunchDarkly.Client.Utils;
 namespace LaunchDarkly.Client.Consul
 {
     /// <summary>
-    /// Builder for a Consul-based implementation of <see cref="IFeatureStore"/>.
-    /// Create an instance of the builder by calling <see cref="ConsulComponents.ConsulFeatureStore"/>;
-    /// configure it using the setter methods; then pass the builder to
-    /// <see cref="ConfigurationExtensions.WithFeatureStore(Configuration, IFeatureStore)"/>.
-    /// 
-    /// The Consul client has many configuration options. This class has shortcut methods for
-    /// some of them, but if you need more sophisticated control over the Consul client, use
-    /// <see cref="WithConfig(Action{ConsulClientConfiguration})"/> or
-    /// <see cref="WithExistingClient(ConsulClient)"/>.
+    /// Obsolete builder for the Consul data store.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This class is retained in version 1.1 of the library for backward compatibility. For the new
+    /// preferred way to configure the Consul integration, see <see cref="LaunchDarkly.Client.Integrations.Consul"/>.
+    /// Updating to the latter now will make it easier to adopt version 6.0 of the LaunchDarkly .NET SDK, since
+    /// an identical API is used there (except for the base namespace).
+    /// </para>
+    /// </remarks>
+    [Obsolete("Use LaunchDarkly.Client.Integrations.Consul")]
     public sealed class ConsulFeatureStoreBuilder : IFeatureStoreFactory
     {
         public const string DefaultPrefix = "launchdarkly";

--- a/src/LaunchDarkly.ServerSdk.Consul/Integrations/Consul.cs
+++ b/src/LaunchDarkly.ServerSdk.Consul/Integrations/Consul.cs
@@ -1,0 +1,36 @@
+﻿
+namespace LaunchDarkly.Client.Integrations
+{
+    /// <summary>
+    /// Integration between the LaunchDarkly SDK and Consul.
+    /// </summary>
+    public static class Consul
+    {
+        /// <summary>
+        /// The default value for <see cref="ConsulDataStoreBuilder.Prefix"/>.
+        /// </summary>
+        public static readonly string DefaultPrefix = "launchdarkly";
+
+        /// <summary>
+        /// Returns a builder object for creating a Consul-backed data store.
+        /// </summary>
+        /// <remarks>
+        /// This object can be modified with <see cref="ConsulDataStoreBuilder"/> methods for any desired
+        /// custom Redis options. Then, pass it to <see cref="Components.PersistentDataStore(Interfaces.IPersistentDataStoreAsyncFactory)"/>
+        /// and set any desired caching options. Finally, pass the result to <see cref="IConfigurationBuilder.DataStore(Interfaces.IFeatureStoreFactory)"/>.
+        /// </remarks>
+        /// <example>
+        /// <code>
+        ///     var config = Configuration.Builder("sdk-key")
+        ///         .DataStore(
+        ///             Components.PersistentDataStore(
+        ///                 Consul.DataStore().Url("redis://my-redis-host")
+        ///             ).CacheSeconds(15)
+        ///         )
+        ///         .Build();
+        /// </code>
+        /// </example>
+        public static ConsulDataStoreBuilder DataStore() =>
+            new ConsulDataStoreBuilder();
+    }
+}

--- a/src/LaunchDarkly.ServerSdk.Consul/Integrations/Consul.cs
+++ b/src/LaunchDarkly.ServerSdk.Consul/Integrations/Consul.cs
@@ -16,7 +16,7 @@ namespace LaunchDarkly.Client.Integrations
         /// </summary>
         /// <remarks>
         /// This object can be modified with <see cref="ConsulDataStoreBuilder"/> methods for any desired
-        /// custom Redis options. Then, pass it to <see cref="Components.PersistentDataStore(Interfaces.IPersistentDataStoreAsyncFactory)"/>
+        /// custom Consul options. Then, pass it to <see cref="Components.PersistentDataStore(Interfaces.IPersistentDataStoreAsyncFactory)"/>
         /// and set any desired caching options. Finally, pass the result to <see cref="IConfigurationBuilder.DataStore(Interfaces.IFeatureStoreFactory)"/>.
         /// </remarks>
         /// <example>
@@ -24,7 +24,7 @@ namespace LaunchDarkly.Client.Integrations
         ///     var config = Configuration.Builder("sdk-key")
         ///         .DataStore(
         ///             Components.PersistentDataStore(
-        ///                 Consul.DataStore().Url("redis://my-redis-host")
+        ///                 Consul.DataStore().Address("http://my-consul-host:8500")
         ///             ).CacheSeconds(15)
         ///         )
         ///         .Build();

--- a/src/LaunchDarkly.ServerSdk.Consul/Integrations/ConsulDataStoreBuilder.cs
+++ b/src/LaunchDarkly.ServerSdk.Consul/Integrations/ConsulDataStoreBuilder.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Generic;
+using Consul;
+using LaunchDarkly.Client.Interfaces;
+using LaunchDarkly.Client.Utils;
+
+namespace LaunchDarkly.Client.Integrations
+{
+    /// <summary>
+    /// A builder for configuring the Consul-based persistent data store.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Obtain an instance of this class by calling <see cref="Consul.DataStore"/>. After calling its methods
+    /// to specify any desired custom settings, wrap it in a <see cref="PersistentDataStoreBuilder"/>
+    /// by calling <see cref="Components.PersistentDataStore(IPersistentDataStoreFactory)"/>, then pass
+    /// the result into the SDK configuration with <see cref="IConfigurationBuilder.DataStore(IFeatureStoreFactory)"/>.
+    /// You do not need to call <see cref="CreatePersistentDataStore()"/> yourself to build
+    /// the actual data store; that will be done by the SDK.
+    /// </para>
+    /// <para>
+    /// The Consul client has many configuration options. This class has shortcut methods for
+    /// some of them, but if you need more sophisticated control over the Consul client, use
+    /// <see cref="ConsulConfigChanges(Action{ConsulClientConfiguration})"/> or
+    /// <see cref="ExistingClient(ConsulClient)"/>.
+    /// </para>
+    /// <para>
+    /// Builder calls can be chained, for example:
+    /// </para>
+    /// <code>
+    ///     var config = Configuration.Builder("sdk-key")
+    ///         .DataStore(
+    ///             Components.PersistentDataStore(
+    ///                 Consul.DataStore()
+    ///                     .Address("http://my-consul-host:8500")
+    ///                     .Prefix("app1")
+    ///                 )
+    ///                 .CacheSeconds(15)
+    ///             )
+    ///         .Build();
+    /// </code>
+    /// </remarks>
+    public sealed class ConsulDataStoreBuilder : IPersistentDataStoreAsyncFactory
+    {
+        private ConsulClient _existingClient;
+        private List<Action<ConsulClientConfiguration>> _configActions = new List<Action<ConsulClientConfiguration>>();
+        private Uri _address;
+        private string _prefix = Consul.DefaultPrefix;
+
+        internal ConsulDataStoreBuilder() { }
+
+        /// <summary>
+        /// Shortcut for calling <see cref="Address(Uri)"/> with a string.
+        /// </summary>
+        /// <param name="address">the URI of the Consul host as a string</param>
+        /// <returns>the builder</returns>
+        /// <seealso cref="Address(Uri)"/>
+        public ConsulDataStoreBuilder Address(string address) => Address(new Uri(address));
+
+        /// <summary>
+        /// Specifies the Consul agent's location.
+        /// </summary>
+        /// <param name="address">the URI of the Consul host</param>
+        /// <returns>the builder</returns>
+        /// /// <seealso cref="Address(string)"/>
+        public ConsulDataStoreBuilder Address(Uri address)
+        {
+            _address = address;
+            return this;
+        }
+
+        /// <summary>
+        /// Specifies custom steps for configuring the Consul client. Your action may modify the
+        /// <see cref="ConsulClientConfiguration"/> object in any way.
+        /// </summary>
+        /// <param name="configAction">an action for modifying the configuration</param>
+        /// <returns>the builder</returns>
+        public ConsulDataStoreBuilder ConsulConfigChanges(Action<ConsulClientConfiguration> configAction)
+        {
+            if (configAction != null)
+            {
+                _configActions.Add(configAction);
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Specifies an existing, already-configured Consul client instance that the data store
+        /// should use rather than creating one of its own.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// If you specify an existing client, then the other builder methods for configuring Consul are ignored.
+        /// </para>
+        /// <para>
+        /// Note that the LaunchDarkly code will <i>not</i> take ownership of the lifecycle of this
+        /// object: in other words, it will not call <c>Dispose()</c> on the <c>ConsulClient</c> when
+        /// you dispose of the SDK client, as it would if it had created the <c>ConsulClient</c> itself.
+        /// It is your responsibility to call <c>Dispose()</c> on the <c>ConsulClient</c> when you are
+        /// done with it.
+        /// </para>
+        /// </remarks>
+        /// <param name="client">an existing Consul client instance</param>
+        /// <returns>the builder</returns>
+        public ConsulDataStoreBuilder ExistingClient(ConsulClient client)
+        {
+            _existingClient = client;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets an optional namespace prefix for all keys stored in Consul.
+        /// </summary>
+        /// <remarks>
+        /// Use this if you are sharing the same database table between multiple clients that are for
+        /// different LaunchDarkly environments, to avoid key collisions.
+        /// </remarks>
+        /// <param name="prefix">the namespace prefix, or null to use <see cref="Consul.DefaultPrefix"/></param>
+        /// <returns>the builder</returns>
+        public ConsulDataStoreBuilder Prefix(string prefix)
+        {
+            _prefix = string.IsNullOrEmpty(prefix) ? Consul.DefaultPrefix : prefix;
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public IFeatureStoreCoreAsync CreatePersistentDataStore()
+        {
+            var client = _existingClient;
+            if (client is null)
+            {
+                client = new ConsulClient(config =>
+                {
+                    if (_address != null)
+                    {
+                        config.Address = _address;
+                    }
+                    foreach (var action in _configActions)
+                    {
+                        action.Invoke(config);
+                    }
+                });
+            }
+
+            return new LaunchDarkly.Client.Consul.ConsulFeatureStoreCore(
+                client,
+                _prefix
+                );
+        }
+    }
+}

--- a/src/LaunchDarkly.ServerSdk.Consul/LaunchDarkly.ServerSdk.Consul.csproj
+++ b/src/LaunchDarkly.ServerSdk.Consul/LaunchDarkly.ServerSdk.Consul.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.1.0-alpha.1</Version>
     <PackageId>LaunchDarkly.ServerSdk.Consul</PackageId>
     <AssemblyName>LaunchDarkly.ServerSdk.Consul</AssemblyName>
     <TargetFrameworks>netstandard1.6;netstandard2.0;net45</TargetFrameworks>
@@ -13,9 +13,12 @@
 
   <ItemGroup>
     <PackageReference Include="Consul" Version="0.7.2.6" />
-    <PackageReference Include="LaunchDarkly.ServerSdk" Version="5.6.4" />
+    <PackageReference Include="LaunchDarkly.ServerSdk" Version="5.14.0-alpha.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Integrations\" />
+  </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
     <DocumentationFile>bin\Release\netstandard2.0\LaunchDarkly.ServerSdk.Consul.xml</DocumentationFile>
   </PropertyGroup>

--- a/src/LaunchDarkly.ServerSdk.Consul/LaunchDarkly.ServerSdk.Consul.csproj
+++ b/src/LaunchDarkly.ServerSdk.Consul/LaunchDarkly.ServerSdk.Consul.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0-alpha.1</Version>
+    <Version>1.1.0</Version>
     <PackageId>LaunchDarkly.ServerSdk.Consul</PackageId>
     <AssemblyName>LaunchDarkly.ServerSdk.Consul</AssemblyName>
     <TargetFrameworks>netstandard1.6;netstandard2.0;net45</TargetFrameworks>
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Consul" Version="0.7.2.6" />
-    <PackageReference Include="LaunchDarkly.ServerSdk" Version="5.14.0-alpha.1" />
+    <PackageReference Include="LaunchDarkly.ServerSdk" Version="5.14.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/LaunchDarkly.ServerSdk.Consul.Tests/ConsulFeatureStoreTest.cs
+++ b/test/LaunchDarkly.ServerSdk.Consul.Tests/ConsulFeatureStoreTest.cs
@@ -13,22 +13,18 @@ namespace LaunchDarkly.Client.Consul.Tests
         
         protected override IFeatureStore CreateStoreImpl(FeatureStoreCacheConfig caching)
         {
-            return BaseBuilder()
-                .WithCaching(caching)
+            return Components.PersistentDataStore(
+                    Integrations.Consul.DataStore()
+                ).CacheTime(caching.Ttl)
                 .CreateFeatureStore();
         }
         
         protected override IFeatureStore CreateStoreImplWithPrefix(string prefix)
         {
-            return BaseBuilder()
-                .WithCaching(FeatureStoreCacheConfig.Disabled)
-                .WithPrefix(prefix)
+            return Components.PersistentDataStore(
+                    Integrations.Consul.DataStore().Prefix(prefix)
+                ).NoCaching()
                 .CreateFeatureStore();
-        }
-
-        private ConsulFeatureStoreBuilder BaseBuilder()
-        {
-            return ConsulComponents.ConsulFeatureStore();
         }
         
         override protected void ClearAllData()


### PR DESCRIPTION
This is for the 1.2 release of `LaunchDarkly.ServerSdk.Consul`; the other PR is for the 2.0 release.

In 1.2, we're deprecating the old Consul config builder, and adding a new entry point and builder that look like the ones we'll be using in 2.0. This corresponds to the .SDK 5.14.0 release which will add configuration APIs that are basically the same as they'll be in 6.0. So, developers who update to this now will have minimal migration to do for SDK 6.0 (except for a search-and-replace to change the namespace from `LaunchDarkly.Client` to `LaunchDarkly.Sdk.Server`. This is basically the same as what we did for Java SDK 5.