### PR TITLE
update to use new docs structure + use latest prerelease SDK

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,12 +14,12 @@ We encourage pull requests and other contributions from the community. Before su
  
 ### Prerequisites
 
-This project has multiple target frameworks as described in [`README.md`](./README.md). The .NET Framework target can be built only in a Windows environment; the others can be built either with or without a Windows environment. Download and install the latest .NET SDK tools first.
+To set up your SDK build time environment, you must [download .NET development tools and follow the instructions](https://dotnet.microsoft.com/download). .NET 5.0 is preferred, since the .NET 5.0 tools are able to build for all supported target platforms.
 
 The project has a package dependency on `Consul`. The dependency version is intended to be the _minimum_ compatible version; applications are expected to override this with their own dependency on some higher version.
 
 The unit test project uses code from the `dotnet-server-sdk-shared-tests` repository which is imported as a subtree. See the `README.md` file in that directory for more information.
- 
+
 ### Building
  
 To install all required packages:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ For more information, see also: [Using a persistent data store](https://docs.lau
 
 Version 2.0.0 and above of this library works with version 6.0.0 and above of the LaunchDarkly .NET SDK. For earlier versions of the SDK, use the latest 1.x release of this library.
 
+For full usage details and examples, see the [API reference](launchdarkly.github.io/dotnet-server-sdk-consul).
+
 ## Supported .NET versions
 
 This version of the library is built for the following targets:
@@ -18,49 +20,6 @@ This version of the library is built for the following targets:
 * .NET Standard 2.0: runs on .NET Core 2.x and 3.x, or .NET 5, in an application; or within a library that is targeted to .NET Standard 2.x or .NET 5.
 
 The .NET build tools should automatically load the most appropriate build of the library for whatever platform your application or library is targeted to.
-
-## Quick setup
-
-1. Use [NuGet](http://docs.nuget.org/docs/start-here/using-the-package-manager-console) to add this package to your project:
-
-        Install-Package LaunchDarkly.ServerSdk.Consul
-
-2. Import the package (note that the namespace is different from the package name):
-
-```csharp
-        using LaunchDarkly.Sdk.Server.Integrations;
-```
-
-3. When configuring your `LdClient`, add the Consul data store as a `PersistentDataStore`. You may specify any custom Consul options using the methods of `ConsulDataStoreBuilder`. For instance, to customize the Consul host address:
-
-```csharp
-        var ldConfig = Configuration.Default("YOUR_SDK_KEY")
-            .DataStore(
-                Components.PersistentDataStore(
-                    Consul.DataStore().Address("http://my-consul-host:8500")
-                )
-            )
-            .Build();
-        var ldClient = new LdClient(ldConfig);
-```
-
-By default, the store will try to connect to a local Consul instance on port 8500.
-
-## Caching behavior
-
-The LaunchDarkly SDK has a standard caching mechanism for any persistent data store, to reduce database traffic. This is configured through the SDK's `PersistentDataStoreBuilder` class as described in the SDK documentation. For instance, to specify a cache TTL of 5 minutes:
-
-```csharp
-        var config = Configuration.Default("YOUR_SDK_KEY")
-            .DataStore(
-                Components.PersistentDataStore(
-                    Consul.DataStore().Address("http://my-consul-host:8500")
-                ).CacheTime(TimeSpan.FromMinutes(5))
-            )
-            .Build();
-```
-
-By default, the store will try to connect to a local Consul instance on port 8500.
 
 ## Signing
 

--- a/docs-src/index.md
+++ b/docs-src/index.md
@@ -1,0 +1,50 @@
+The [`LaunchDarkly.ServerSdk.Consul`](https://nuget.org/packages/LaunchDarkly.ServerSdk.Consul) package provides a Consul-backed persistence mechanism (data store) for the [LaunchDarkly .NET SDK](https://github.com/launchdarkly/dotnet-server-sdk), replacing the default in-memory data store. The underlying Consul client implementation is https://github.com/PlayFab/consuldotnet.
+
+For more information, see also: [Using a persistent data store](https://docs.launchdarkly.com/v2.0/docs/using-a-persistent-feature-store).
+
+Version 2.0.0 and above of this library works with version 6.0.0 and above of the LaunchDarkly .NET SDK. For earlier versions of the SDK, use the latest 1.x release of this library.
+
+The entry point for using this integration is the **<xref:LaunchDarkly.Sdk.Server.Integrations.Consul>** class in <xref:LaunchDarkly.Sdk.Server.Integrations>.
+
+## Quick setup
+
+This assumes that you have already installed the LaunchDarkly .NET SDK.
+
+1. Add the NuGet package [`LaunchDarkly.ServerSdk.Consul`](https://nuget.org/packages/LaunchDarkly.ServerSdk.Consul) to your project.
+
+2. Import the package (note that the namespace is different from the package name):
+
+```csharp
+        using LaunchDarkly.Sdk.Server.Integrations;
+```
+
+3. When configuring your `LdClient`, add the Consul data store as a `PersistentDataStore`. You may specify any custom Consul options using the methods of `ConsulDataStoreBuilder`. For instance, to customize the Consul host address:
+
+```csharp
+        var ldConfig = Configuration.Default("YOUR_SDK_KEY")
+            .DataStore(
+                Components.PersistentDataStore(
+                    Consul.DataStore().Address("http://my-consul-host:8500")
+                )
+            )
+            .Build();
+        var ldClient = new LdClient(ldConfig);
+```
+
+By default, the store will try to connect to a local Consul instance on port 8500.
+
+## Caching behavior
+
+The LaunchDarkly SDK has a standard caching mechanism for any persistent data store, to reduce database traffic. This is configured through the SDK's `PersistentDataStoreBuilder` class as described in the SDK documentation. For instance, to specify a cache TTL of 5 minutes:
+
+```csharp
+        var config = Configuration.Default("YOUR_SDK_KEY")
+            .DataStore(
+                Components.PersistentDataStore(
+                    Consul.DataStore().Address("http://my-consul-host:8500")
+                ).CacheTime(TimeSpan.FromMinutes(5))
+            )
+            .Build();
+```
+
+By default, the store will try to connect to a local Consul instance on port 8500.

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/LaunchDarkly.ServerSdk.SharedTests.csproj
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/LaunchDarkly.ServerSdk.SharedTests.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.ServerSdk" Version="[6.0.0-alpha.9,]" />
-    <PackageReference Include="LaunchDarkly.Logging" Version="[1.0.0,]" />
+    <PackageReference Include="LaunchDarkly.ServerSdk" Version="[6.0.0-rc.1,]" />
+    <PackageReference Include="LaunchDarkly.Logging" Version="[1.0.1,]" />
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 </Project>

--- a/src/LaunchDarkly.ServerSdk.Consul/LaunchDarkly.ServerSdk.Consul.csproj
+++ b/src/LaunchDarkly.ServerSdk.Consul/LaunchDarkly.ServerSdk.Consul.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Consul" Version="[0.7.2.6,]" />
-    <PackageReference Include="LaunchDarkly.ServerSdk" Version="[6.0.0-alpha.9,]" />
+    <PackageReference Include="LaunchDarkly.ServerSdk" Version="[6.0.0-rc.1]" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This moves the main API doc content out of the obsolete `NamespaceDoc.cs` file into the new structure we use with DocFX, and generally improves some of the readme content. You can see a temporary build of the docs [here](https://83-163905521-gh.circle-artifacts.com/0/artifacts/index.html).