### PR TITLE
updates for prerelease 7.0 SDK

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,13 +13,13 @@ workflows:
 jobs:
   test_dotnetcore:
     docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:2.1-focal
+      - image: mcr.microsoft.com/dotnet/core/sdk:3.1-focal
       - image: consul
     steps:
       - checkout
       - run: dotnet restore
       - run: dotnet build src/LaunchDarkly.ServerSdk.Consul -f netstandard2.0
-      - run: dotnet test test/LaunchDarkly.ServerSdk.Consul.Tests -f netcoreapp2.1
+      - run: dotnet test test/LaunchDarkly.ServerSdk.Consul.Tests -f netcoreapp3.1
 
   test_dotnetframework:
     executor:
@@ -35,5 +35,5 @@ jobs:
           command: consul agent -dev
           background: true
       - run: dotnet restore
-      - run: dotnet build src/LaunchDarkly.ServerSdk.Consul -f net452
-      - run: dotnet test test/LaunchDarkly.ServerSdk.Consul.Tests -f net452
+      - run: dotnet build src/LaunchDarkly.ServerSdk.Consul -f net462
+      - run: dotnet test test/LaunchDarkly.ServerSdk.Consul.Tests -f net462

--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -6,14 +6,16 @@ publications:
 
 branches:
   - name: main
-    description: 2.x - for SDK 6+
+    description: 3.x - for SDK 7+
+  - name: 2.x
+    description: for SDK 6.x
   - name: 1.x
     description: for SDK 5.x
 
 jobs:
   - docker: {}
     template:
-      name: dotnet-linux
+      name: dotnet6-linux
       skip:
         - test
     env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ We encourage pull requests and other contributions from the community. Before su
  
 ### Prerequisites
 
-To set up your SDK build time environment, you must [download .NET development tools and follow the instructions](https://dotnet.microsoft.com/download). .NET 5.0 is preferred, since the .NET 5.0 tools are able to build for all supported target platforms.
+To set up your SDK build time environment, you must [download .NET development tools and follow the instructions](https://dotnet.microsoft.com/download). .NET 6.0 is preferred, since the .NET 6.0 tools are able to build for all supported target platforms.
 
 The project has a package dependency on `Consul`. The dependency version is intended to be the _minimum_ compatible version; applications are expected to override this with their own dependency on some higher version.
 
@@ -50,10 +50,10 @@ To run all unit tests, for all targets (this includes .NET Framework, so you can
 dotnet test test/LaunchDarkly.ServerSdk.Consul.Tests
 ```
 
-Or, to run tests only for one target (in this case .NET Core 2.1):
+Or, to run tests only for one target (in this case .NET Core 3.1):
 
 ```
-dotnet test test/LaunchDarkly.ServerSdk.Consul.Tests -f netcoreapp2.1
+dotnet test test/LaunchDarkly.ServerSdk.Consul.Tests -f netcoreapp3.1
 ```
 
 The tests expect you to have Consul running locally on the default port, 8500. One way to do this is with Docker:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This library provides a Consul-backed persistence mechanism (data store) for the
 
 For more information, see also: [Using a persistent data store](https://docs.launchdarkly.com/v2.0/docs/using-a-persistent-feature-store).
 
-Version 2.0.0 and above of this library works with version 6.0.0 and above of the LaunchDarkly .NET SDK. For earlier versions of the SDK, use the latest 1.x release of this library.
+Version 3.0.0 and above of this library works with version 7.0.0 and above of the LaunchDarkly .NET SDK. For earlier versions of the SDK, see the changelog for which version of this library to use.
 
 For full usage details and examples, see the [API reference](launchdarkly.github.io/dotnet-server-sdk-consul).
 
@@ -16,8 +16,8 @@ For full usage details and examples, see the [API reference](launchdarkly.github
 
 This version of the library is built for the following targets:
 
-* .NET Framework 4.5.2: runs on .NET Framework 4.5.x and above.
-* .NET Standard 2.0: runs on .NET Core 2.x and 3.x, or .NET 5, in an application; or within a library that is targeted to .NET Standard 2.x or .NET 5.
+* .NET Framework 4.6.2: works in .NET Framework of that version or higher.
+* .NET Standard 2.0: works in .NET Core 3.x, .NET 6.x, or in a library targeted to .NET Standard 2.x.
 
 The .NET build tools should automatically load the most appropriate build of the library for whatever platform your application or library is targeted to.
 

--- a/dotnet-server-sdk-shared-tests/.circleci/config.yml
+++ b/dotnet-server-sdk-shared-tests/.circleci/config.yml
@@ -7,9 +7,9 @@ workflows:
 jobs:
   test:
     docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:2.1-focal
+      - image: mcr.microsoft.com/dotnet/core/sdk:3.1-focal
     steps:
       - checkout
       - run: dotnet restore
-      - run: dotnet build LaunchDarkly.ServerSdk.SharedTests
+      - run: dotnet build LaunchDarkly.ServerSdk.SharedTests -f netstandard2.0
       - run: dotnet test LaunchDarkly.ServerSdk.SharedTests.Tests/LaunchDarkly.ServerSdk.SharedTests.Tests.csproj

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests.Tests/BigSegmentStore/BigSegmentStoreBaseTestsTest.cs
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests.Tests/BigSegmentStore/BigSegmentStoreBaseTestsTest.cs
@@ -1,0 +1,108 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using LaunchDarkly.Sdk.Server.Subsystems;
+using Xunit.Abstractions;
+
+using static LaunchDarkly.Sdk.Server.Subsystems.BigSegmentStoreTypes;
+
+namespace LaunchDarkly.Sdk.Server.SharedTests.BigSegmentStore
+{
+    public class BigSegmentStoreBaseTestsTest : BigSegmentStoreBaseTests
+    {
+        // This runs BigSegmentStoreBaseTests against a mock store implementation that is known to
+        // behave as expected, to verify that the test suite logic has the correct expectations.
+
+        protected override BigSegmentStoreTestConfig Configuration =>
+            new BigSegmentStoreTestConfig
+            {
+                StoreFactoryFunc = CreateStoreFactory,
+                ClearDataAction = ClearData,
+                SetMetadataAction = SetMetadata,
+                SetSegmentsAction = SetSegments
+            };
+
+        private class DataSet {
+            public StoreMetadata? Metadata = null;
+            public Dictionary<string, IMembership> Memberships = new Dictionary<string, IMembership>();
+        }
+
+        private readonly Dictionary<string, DataSet> _allData = new Dictionary<string, DataSet>();
+
+        public BigSegmentStoreBaseTestsTest(ITestOutputHelper testOutput) : base(testOutput)
+        {
+        }
+
+        private IComponentConfigurer<IBigSegmentStore> CreateStoreFactory(string prefix) =>
+            new MockStoreFactory(GetOrCreateDataSet(prefix));
+
+        private Task ClearData(string prefix)
+        {
+            var data = GetOrCreateDataSet(prefix);
+            data.Metadata = null;
+            data.Memberships.Clear();
+            return Task.CompletedTask;
+        }
+
+        private Task SetMetadata(string prefix, StoreMetadata metadata)
+        {
+            GetOrCreateDataSet(prefix).Metadata = metadata;
+            return Task.CompletedTask;
+        }
+
+        private Task SetSegments(string prefix, string userHashKey,
+            IEnumerable<string> includedSegmentRefs, IEnumerable<string> excludedSegmentRefs)
+        {
+            GetOrCreateDataSet(prefix).Memberships[userHashKey] =
+                NewMembershipFromSegmentRefs(includedSegmentRefs, excludedSegmentRefs);
+            return Task.CompletedTask;
+        }
+
+        private DataSet GetOrCreateDataSet(string prefix)
+        {
+            if (!_allData.ContainsKey(prefix))
+            {
+                _allData[prefix] = new DataSet();
+            }
+            return _allData[prefix];
+        }
+
+        private class MockStoreFactory : IComponentConfigurer<IBigSegmentStore>
+        {
+            private readonly DataSet _data;
+
+            public MockStoreFactory(DataSet data)
+            {
+                _data = data;
+            }
+
+            public IBigSegmentStore Build(LdClientContext context) =>
+                new MockStore(_data);
+        }
+
+        private class MockStore : IBigSegmentStore
+        {
+            private readonly DataSet _data;
+
+            public MockStore(DataSet data)
+            {
+                _data = data;
+            }
+
+            public void Dispose() { }
+
+            public Task<IMembership> GetMembershipAsync(string userHash)
+            {
+                if (_data.Memberships.TryGetValue(userHash, out var result))
+                {
+                    return Task.FromResult(result);
+                }
+                return Task.FromResult((IMembership)null);
+            }
+
+            public Task<StoreMetadata?> GetMetadataAsync()
+            {
+                return Task.FromResult(_data.Metadata);
+            }
+        }
+    }
+}

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests.Tests/DataStore/MockAsyncStore.cs
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests.Tests/DataStore/MockAsyncStore.cs
@@ -1,7 +1,7 @@
 ﻿using System.Threading.Tasks;
-using LaunchDarkly.Sdk.Server.Interfaces;
+using LaunchDarkly.Sdk.Server.Subsystems;
 
-using static LaunchDarkly.Sdk.Server.Interfaces.DataStoreTypes;
+using static LaunchDarkly.Sdk.Server.Subsystems.DataStoreTypes;
 
 namespace LaunchDarkly.Sdk.Server.SharedTests.DataStore
 {

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests.Tests/DataStore/MockDatabase.cs
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests.Tests/DataStore/MockDatabase.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-using static LaunchDarkly.Sdk.Server.Interfaces.DataStoreTypes;
+using static LaunchDarkly.Sdk.Server.Subsystems.DataStoreTypes;
 
 namespace LaunchDarkly.Sdk.Server.SharedTests.DataStore
 {

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests.Tests/DataStore/MockSyncStore.cs
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests.Tests/DataStore/MockSyncStore.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
-using LaunchDarkly.Sdk.Server.Interfaces;
+using LaunchDarkly.Sdk.Server.Subsystems;
 
-using static LaunchDarkly.Sdk.Server.Interfaces.DataStoreTypes;
+using static LaunchDarkly.Sdk.Server.Subsystems.DataStoreTypes;
 
 namespace LaunchDarkly.Sdk.Server.SharedTests.DataStore
 {

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests.Tests/DataStore/PersistentDataStoreBaseTestsAsyncTest.cs
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests.Tests/DataStore/PersistentDataStoreBaseTestsAsyncTest.cs
@@ -1,5 +1,5 @@
 ﻿using System.Threading.Tasks;
-using LaunchDarkly.Sdk.Server.Interfaces;
+using LaunchDarkly.Sdk.Server.Subsystems;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -20,7 +20,7 @@ namespace LaunchDarkly.Sdk.Server.SharedTests.DataStore
 
         public PersistentDataStoreBaseTestsAsyncTest(ITestOutputHelper testOutput) : base(testOutput) { }
 
-        private IPersistentDataStoreAsyncFactory CreateStoreFactory(string prefix) =>
+        private IComponentConfigurer<IPersistentDataStoreAsync> CreateStoreFactory(string prefix) =>
             new MockAsyncStoreFactory { Database = MockDatabase.Instance, Prefix = prefix };
 
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
@@ -28,12 +28,12 @@ namespace LaunchDarkly.Sdk.Server.SharedTests.DataStore
             MockDatabase.Instance.Clear(prefix);
 #pragma warning restore CS1998
 
-        private class MockAsyncStoreFactory : IPersistentDataStoreAsyncFactory
+        private class MockAsyncStoreFactory : IComponentConfigurer<IPersistentDataStoreAsync>
         {
             internal MockDatabase Database { get; set; }
             internal string Prefix { get; set; }
 
-            public IPersistentDataStoreAsync CreatePersistentDataStore(LdClientContext context) =>
+            public IPersistentDataStoreAsync Build(LdClientContext context) =>
                 new MockAsyncStore(Database, Prefix);
         }
     }

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests.Tests/DataStore/PersistentDataStoreBaseTestsSyncTest.cs
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests.Tests/DataStore/PersistentDataStoreBaseTestsSyncTest.cs
@@ -1,5 +1,5 @@
 ﻿using System.Threading.Tasks;
-using LaunchDarkly.Sdk.Server.Interfaces;
+using LaunchDarkly.Sdk.Server.Subsystems;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -20,7 +20,7 @@ namespace LaunchDarkly.Sdk.Server.SharedTests.DataStore
 
         public PersistentDataStoreBaseTestsSyncTest(ITestOutputHelper testOutput) : base(testOutput) { }
 
-        private IPersistentDataStoreFactory CreateStoreFactory(string prefix) =>
+        private IComponentConfigurer<IPersistentDataStore> CreateStoreFactory(string prefix) =>
             new MockSyncStoreFactory { Database = MockDatabase.Instance, Prefix = prefix };
 
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
@@ -28,12 +28,12 @@ namespace LaunchDarkly.Sdk.Server.SharedTests.DataStore
             MockDatabase.Instance.Clear(prefix);
 #pragma warning restore CS1998
 
-        private class MockSyncStoreFactory : IPersistentDataStoreFactory
+        private class MockSyncStoreFactory : IComponentConfigurer<IPersistentDataStore>
         {
             internal MockDatabase Database { get; set; }
             internal string Prefix { get; set; }
 
-            public IPersistentDataStore CreatePersistentDataStore(LdClientContext context) =>
+            public IPersistentDataStore Build(LdClientContext context) =>
                 new MockSyncStore(Database, Prefix);
         }
     }

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests.Tests/LaunchDarkly.ServerSdk.SharedTests.Tests.csproj
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests.Tests/LaunchDarkly.ServerSdk.SharedTests.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <RootNamespace>LaunchDarkly.Sdk.Server.SharedTests</RootNamespace>
   </PropertyGroup>

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/BigSegmentStore/BigSegmentStoreBaseTests.cs
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/BigSegmentStore/BigSegmentStoreBaseTests.cs
@@ -1,0 +1,149 @@
+﻿using System.Threading.Tasks;
+using LaunchDarkly.Logging;
+using LaunchDarkly.Sdk.Server.Subsystems;
+using Xunit;
+using Xunit.Abstractions;
+
+using static LaunchDarkly.Sdk.Server.Subsystems.BigSegmentStoreTypes;
+
+namespace LaunchDarkly.Sdk.Server.SharedTests.BigSegmentStore
+{
+    /// <summary>
+    /// A configurable Xunit test class for all implementations of <c>IBigSegmentStore</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Each implementation of those interfaces should define a test class that is a subclass of this
+    /// class for their implementation type, and run it in the unit tests for their project.
+    /// </para>
+    /// <para>
+    /// You must override the <see cref="Configuration"/> property to provide details specific to
+    /// your implementation type.
+    /// </para>
+    /// </remarks>
+    public abstract class BigSegmentStoreBaseTests
+    {
+        /// <summary>
+        /// Override this method to create the configuration for the test suite.
+        /// </summary>
+        protected abstract BigSegmentStoreTestConfig Configuration { get; }
+
+        private const string prefix = "testprefix";
+        private const string fakeUserHash = "userhash";
+        private const string segmentRef1 = "key1", segmentRef2 = "key2", segmentRef3 = "key3";
+        private static readonly string[] allSegmentRefs = new string[] { segmentRef1, segmentRef2, segmentRef3 };
+
+        private readonly ILogAdapter _testLogging;
+
+        protected BigSegmentStoreBaseTests()
+        {
+            _testLogging = Logs.None;
+        }
+
+        protected BigSegmentStoreBaseTests(ITestOutputHelper testOutput)
+        {
+            _testLogging = TestLogging.TestOutputAdapter(testOutput);
+        }
+
+        private IBigSegmentStore MakeStore()
+        {
+            var context = new LdClientContext("sdk-key", null, null,
+                Components.HttpConfiguration().Build(new LdClientContext("sdk-key")), _testLogging.Logger(""), false, null);
+            return Configuration.StoreFactoryFunc(prefix).Build(context);
+        }
+
+        private async Task<IBigSegmentStore> MakeEmptyStore()
+        {
+            var store = MakeStore();
+            try
+            {
+                await Configuration.ClearDataAction(prefix);
+            }
+            catch
+            {
+                store.Dispose();
+                throw;
+            }
+            return store;
+        }
+
+        [Fact]
+        public async void MissingMetadata()
+        {
+            using (var store = await MakeEmptyStore())
+            {
+                Assert.Null(await store.GetMetadataAsync());
+            }
+        }
+
+        [Fact]
+        public async void ValidMetadata()
+        {
+            using (var store = await MakeEmptyStore())
+            {
+                var metadata = new StoreMetadata { LastUpToDate = UnixMillisecondTime.Now };
+                await Configuration.SetMetadataAction(prefix, metadata);
+
+                var result = await store.GetMetadataAsync();
+                Assert.NotNull(result);
+                Assert.Equal(metadata.LastUpToDate, result.Value.LastUpToDate);
+            }
+        }
+
+        [Fact]
+        public async void MembershipNotFound()
+        {
+            using (var store = await MakeEmptyStore())
+            {
+                var membership = await store.GetMembershipAsync(fakeUserHash);
+
+                // Either null or an empty membership is allowed in this case
+                if (membership != null)
+                {
+                    AssertEqualMembership(NewMembershipFromSegmentRefs(null, null), membership);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(new string[] { segmentRef1 }, new string[] { })]
+        [InlineData(new string[] { segmentRef1, segmentRef2 }, new string[] { })]
+        [InlineData(new string[] { }, new string[] { segmentRef1 })]
+        [InlineData(new string[] { }, new string[] { segmentRef1, segmentRef2 })]
+        [InlineData(new string[] { segmentRef1, segmentRef2 }, new string[] { segmentRef2, segmentRef3 })]
+        public async void MembershipFound(string[] includes, string[] excludes)
+        {
+            using (var store = await MakeEmptyStore())
+            {
+                await Configuration.SetSegmentsAction(prefix, fakeUserHash, includes, excludes);
+
+                var membership = await store.GetMembershipAsync(fakeUserHash);
+
+                AssertEqualMembership(NewMembershipFromSegmentRefs(includes, excludes), membership);
+            }
+        }
+
+        private static void AssertEqualMembership(IMembership expected, IMembership actual)
+        {
+            if (actual.GetType().FullName.StartsWith("LaunchDarkly.Sdk.Server.Internal.BigSegments.MembershipBuilder"))
+            {
+                // The store implementation is using our standard membership types, so we can rely on the
+                // standard equality test for those
+                Assert.Equal(expected, actual);
+            }
+            else
+            {
+                // The store implementation has implemented IMembership in some other way, so we have to
+                // check for the inclusion or exclusion of specific keys
+                foreach (var segmentRef in allSegmentRefs)
+                {
+                    if (actual.CheckMembership(segmentRef) != expected.CheckMembership(segmentRef))
+                    {
+                        Assert.True(false, string.Format("expected membership for {0} to be {1} but was {2}",
+                            segmentRef, expected.CheckMembership(segmentRef), actual.CheckMembership(segmentRef)));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/BigSegmentStore/BigSegmentStoreTestConfig.cs
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/BigSegmentStore/BigSegmentStoreTestConfig.cs
@@ -1,0 +1,67 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using LaunchDarkly.Sdk.Server.Subsystems;
+
+using static LaunchDarkly.Sdk.Server.Subsystems.BigSegmentStoreTypes;
+
+namespace LaunchDarkly.Sdk.Server.SharedTests.BigSegmentStore
+{
+    /// <summary>
+    /// A function that takes a prefix string and returns a configured factory for
+    /// your implementation of <c>IBigSegmentStore</c>.
+    /// </summary>
+    /// <remarks>
+    /// If the prefix string is null or "", it should use the default prefix defined by the
+    /// data store implementation. The factory must include any necessary configuration that
+    /// may be appropriate for the test environment (for instance, pointing it to a database
+    /// instance that has been set up for the tests).
+    /// </remarks>
+    /// <param name="prefix">the database prefix</param>
+    /// <returns>a configured factory</returns>
+    public delegate IComponentConfigurer<IBigSegmentStore> StoreFactoryFunc(string prefix);
+
+    /// <summary>
+    /// An asynchronous function that removes all data from the underlying
+    /// data store for the specified prefix string.
+    /// </summary>
+    /// <param name="prefix">the database prefix</param>
+    /// <returns>an asynchronous task</returns>
+    public delegate Task ClearDataAction(string prefix);
+
+    /// <summary>
+    /// An asynchronous function that updates the store metadata to the specified values.
+    /// This must be provided separately by the test code because the store interface used by
+    /// the SDK has no update methods.
+    /// </summary>
+    /// <param name="prefix">the database prefix</param>
+    /// <param name="metadata">the data to write to the store</param>
+    /// <returns>an asynchronous task</returns>
+    public delegate Task SetMetadataAction(string prefix, StoreMetadata metadata);
+
+    /// <summary>
+    /// An asynchronous function that updates the membership state for a user in the store.
+    /// This must be provided separately by the test code because the store interface used by
+    /// the SDK has no update methods.
+    /// </summary>
+    /// <param name="prefix">the database prefix</param>
+    /// <param name="userHashKey">the hashed user key</param>
+    /// <param name="includedSegmentRefs">segment references to be included</param>
+    /// <param name="excludedSegmentRefs">segment references to be excluded</param>
+    /// <returns>an asynchronous task</returns>
+    public delegate Task SetSegmentsAction(string prefix, string userHashKey,
+        IEnumerable<string> includedSegmentRefs, IEnumerable<string> excludedSegmentRefs);
+
+    /// <summary>
+    /// Configuration for <see cref="BigSegmentStoreBaseTests"/>.
+    /// </summary>
+    public sealed class BigSegmentStoreTestConfig
+    {
+        public StoreFactoryFunc StoreFactoryFunc { get; set; }
+
+        public ClearDataAction ClearDataAction { get; set; }
+
+        public SetMetadataAction SetMetadataAction { get; set; }
+
+        public SetSegmentsAction SetSegmentsAction { get; set; }
+    }
+}

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/DataStore/DataBuilder.cs
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/DataStore/DataBuilder.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-using static LaunchDarkly.Sdk.Server.Interfaces.DataStoreTypes;
+using static LaunchDarkly.Sdk.Server.Subsystems.DataStoreTypes;
 
 namespace LaunchDarkly.Sdk.Server.SharedTests.DataStore
 {

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/DataStore/FlagTestData.cs
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/DataStore/FlagTestData.cs
@@ -1,12 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using LaunchDarkly.Logging;
-using LaunchDarkly.Sdk.Server.Interfaces;
-using Xunit;
+﻿using System.Collections.Generic;
 
-using static LaunchDarkly.Sdk.Server.Interfaces.DataStoreTypes;
+using static LaunchDarkly.Sdk.Server.Subsystems.DataStoreTypes;
 
 namespace LaunchDarkly.Sdk.Server.SharedTests.DataStore
 {
@@ -20,8 +14,8 @@ namespace LaunchDarkly.Sdk.Server.SharedTests.DataStore
 
         public const int GoodVariation1 = 0, GoodVariation2 = 1, BadVariation = 2;
 
-        public static readonly User MainUser = User.WithKey(UserKey),
-            OtherUser = User.WithKey(OtherUserKey);
+        public static readonly Context MainUser = Context.New(UserKey),
+            OtherUser = Context.New(OtherUserKey);
 
         public static ItemDescriptor MakeFlagThatReturnsVariationForSegmentMatch(int version, int variation)
         {

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/DataStore/PersistentDataStoreTestConfig.cs
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/DataStore/PersistentDataStoreTestConfig.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
-using LaunchDarkly.Sdk.Server.Interfaces;
+using LaunchDarkly.Sdk.Server.Subsystems;
 
 namespace LaunchDarkly.Sdk.Server.SharedTests.DataStore
 {
@@ -21,7 +21,7 @@ namespace LaunchDarkly.Sdk.Server.SharedTests.DataStore
         /// may be appropriate for the test environment (for instance, pointing it to a database
         /// instance that has been set up for the tests).
         /// </remarks>
-        public Func<string, IPersistentDataStoreFactory> StoreFactoryFunc { get; set; }
+        public Func<string, IComponentConfigurer<IPersistentDataStore>> StoreFactoryFunc { get; set; }
 
         /// <summary>
         /// Set this to a function that takes a prefix string and returns a configured factory for
@@ -34,7 +34,7 @@ namespace LaunchDarkly.Sdk.Server.SharedTests.DataStore
         /// may be appropriate for the test environment (for instance, pointing it to a database
         /// instance that has been set up for the tests).
         /// </remarks>
-        public Func<string, IPersistentDataStoreAsyncFactory> StoreAsyncFactoryFunc { get; set; }
+        public Func<string, IComponentConfigurer<IPersistentDataStoreAsync>> StoreAsyncFactoryFunc { get; set; }
         
         /// <summary>
         /// Set this to an asynchronous function that removes all data from the underlying

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/DataStore/TestEntity.cs
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/DataStore/TestEntity.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using static LaunchDarkly.Sdk.Server.Interfaces.DataStoreTypes;
+﻿using static LaunchDarkly.Sdk.Server.Subsystems.DataStoreTypes;
 
 namespace LaunchDarkly.Sdk.Server.SharedTests.DataStore
 {

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/LaunchDarkly.ServerSdk.SharedTests.csproj
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/LaunchDarkly.ServerSdk.SharedTests.csproj
@@ -3,7 +3,7 @@
     <Version>2.0.0-alpha.2</Version>
     <PackageId>LaunchDarkly.ServerSdk.SharedTests</PackageId>
     <AssemblyName>LaunchDarkly.ServerSdk.SharedTests</AssemblyName>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <OutputType>Library</OutputType>
     <Description>LaunchDarkly .NET Shared Tests</Description>
     <Company>LaunchDarkly</Company>
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.ServerSdk" Version="[6.0.0,7.0.0)" />
-    <PackageReference Include="LaunchDarkly.Logging" Version="[1.0.1,]" />
+    <PackageReference Include="LaunchDarkly.ServerSdk" Version="7.0.0-alpha.3" />
+    <PackageReference Include="LaunchDarkly.Logging" Version="[2.0.0,3.0.0)" />
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 </Project>

--- a/src/LaunchDarkly.ServerSdk.Consul/Consul.cs
+++ b/src/LaunchDarkly.ServerSdk.Consul/Consul.cs
@@ -13,14 +13,30 @@ namespace LaunchDarkly.Sdk.Server.Integrations
         public static readonly string DefaultPrefix = "launchdarkly";
 
         /// <summary>
-        /// Returns a builder object for creating a Consul-backed data store.
+        /// Returns a builder object for creating a Consul-backed persistent data store.
         /// </summary>
         /// <remarks>
-        /// This object can be modified with <see cref="ConsulDataStoreBuilder"/> methods for any desired
-        /// custom Consul options. Then, pass it to <see cref="Components.PersistentDataStore(IComponentConfigurer{IPersistentDataStoreAsync})"/>
-        /// and set any desired caching options. Finally, pass the result to <see cref="ConfigurationBuilder.DataStore(IComponentConfigurer{IDataStore})"/>.
-        /// </remarks>
-        /// <example>
+        /// <para>
+        /// You can use methods of the builder to specify any non-default Consul options
+        /// you may want, before passing the builder to
+        /// <see cref="Components.PersistentDataStore(IComponentConfigurer{IPersistentDataStore})"/>.
+        /// In this example, the store is configured with only the host address:
+        /// </para>
+        /// <code>
+        ///     var config = Configuration.Builder("sdk-key")
+        ///         .DataStore(
+        ///             Components.PersistentDataStore(
+        ///                 Consul.DataStore().Address("http://my-consul-host:8500")
+        ///             )
+        ///         )
+        ///         .Build();
+        /// </code>
+        /// <para>
+        /// Note that the SDK also has its own options related to data storage that are configured
+        /// at a different level, because they are independent of what database is being used. For
+        /// instance, the builder returned by <see cref="Components.PersistentDataStore(IComponentConfigurer{IPersistentDataStore})"/>
+        /// has options for caching:
+        /// </para>
         /// <code>
         ///     var config = Configuration.Builder("sdk-key")
         ///         .DataStore(
@@ -30,7 +46,8 @@ namespace LaunchDarkly.Sdk.Server.Integrations
         ///         )
         ///         .Build();
         /// </code>
-        /// </example>
+        /// </remarks>
+        /// <returns>a data store configuration object</returns>
         public static ConsulDataStoreBuilder DataStore() =>
             new ConsulDataStoreBuilder();
     }

--- a/src/LaunchDarkly.ServerSdk.Consul/Consul.cs
+++ b/src/LaunchDarkly.ServerSdk.Consul/Consul.cs
@@ -1,4 +1,5 @@
-﻿
+﻿using LaunchDarkly.Sdk.Server.Subsystems;
+
 namespace LaunchDarkly.Sdk.Server.Integrations
 {
     /// <summary>
@@ -16,8 +17,8 @@ namespace LaunchDarkly.Sdk.Server.Integrations
         /// </summary>
         /// <remarks>
         /// This object can be modified with <see cref="ConsulDataStoreBuilder"/> methods for any desired
-        /// custom Consul options. Then, pass it to <see cref="Components.PersistentDataStore(Interfaces.IPersistentDataStoreAsyncFactory)"/>
-        /// and set any desired caching options. Finally, pass the result to <see cref="ConfigurationBuilder.DataStore(Interfaces.IDataStoreFactory)"/>.
+        /// custom Consul options. Then, pass it to <see cref="Components.PersistentDataStore(IComponentConfigurer{IPersistentDataStoreAsync})"/>
+        /// and set any desired caching options. Finally, pass the result to <see cref="ConfigurationBuilder.DataStore(IComponentConfigurer{IDataStore})"/>.
         /// </remarks>
         /// <example>
         /// <code>

--- a/src/LaunchDarkly.ServerSdk.Consul/ConsulDataStoreBuilder.cs
+++ b/src/LaunchDarkly.ServerSdk.Consul/ConsulDataStoreBuilder.cs
@@ -39,7 +39,8 @@ namespace LaunchDarkly.Sdk.Server.Integrations
     ///         .Build();
     /// </code>
     /// </remarks>
-    public sealed class ConsulDataStoreBuilder : IComponentConfigurer<IPersistentDataStoreAsync>
+    public sealed class ConsulDataStoreBuilder : IComponentConfigurer<IPersistentDataStoreAsync>,
+        IDiagnosticDescription
     {
         private ConsulClient _existingClient;
         private List<Action<ConsulClientConfiguration>> _configActions = new List<Action<ConsulClientConfiguration>>();
@@ -148,5 +149,9 @@ namespace LaunchDarkly.Sdk.Server.Integrations
                 context.Logger.SubLogger("DataStore.Consul")
                 );
         }
+
+        /// <inheritdoc/>
+        public LdValue DescribeConfiguration(LdClientContext context) =>
+            LdValue.Of("Consul");
     }
 }

--- a/src/LaunchDarkly.ServerSdk.Consul/ConsulDataStoreBuilder.cs
+++ b/src/LaunchDarkly.ServerSdk.Consul/ConsulDataStoreBuilder.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Consul;
-using LaunchDarkly.Sdk.Server.Interfaces;
+using LaunchDarkly.Sdk.Server.Subsystems;
 
 namespace LaunchDarkly.Sdk.Server.Integrations
 {
@@ -12,9 +12,9 @@ namespace LaunchDarkly.Sdk.Server.Integrations
     /// <para>
     /// Obtain an instance of this class by calling <see cref="Consul.DataStore"/>. After calling its methods
     /// to specify any desired custom settings, wrap it in a <see cref="PersistentDataStoreBuilder"/>
-    /// by calling <see cref="Components.PersistentDataStore(IPersistentDataStoreFactory)"/>, then pass
-    /// the result into the SDK configuration with <see cref="ConfigurationBuilder.DataStore(IDataStoreFactory)"/>.
-    /// You do not need to call <see cref="CreatePersistentDataStore(LdClientContext)"/> yourself to build
+    /// by calling <see cref="Components.PersistentDataStore(IComponentConfigurer{IPersistentDataStoreAsync})"/>, then pass
+    /// the result into the SDK configuration with <see cref="ConfigurationBuilder.DataStore(IComponentConfigurer{IDataStore})"/>.
+    /// You do not need to call <see cref="Build(LdClientContext)"/> yourself to build
     /// the actual data store; that will be done by the SDK.
     /// </para>
     /// <para>
@@ -39,7 +39,7 @@ namespace LaunchDarkly.Sdk.Server.Integrations
     ///         .Build();
     /// </code>
     /// </remarks>
-    public sealed class ConsulDataStoreBuilder : IPersistentDataStoreAsyncFactory
+    public sealed class ConsulDataStoreBuilder : IComponentConfigurer<IPersistentDataStoreAsync>
     {
         private ConsulClient _existingClient;
         private List<Action<ConsulClientConfiguration>> _configActions = new List<Action<ConsulClientConfiguration>>();
@@ -123,7 +123,7 @@ namespace LaunchDarkly.Sdk.Server.Integrations
         }
 
         /// <inheritdoc/>
-        public IPersistentDataStoreAsync CreatePersistentDataStore(LdClientContext context)
+        public IPersistentDataStoreAsync Build(LdClientContext context)
         {
             var client = _existingClient;
             if (client is null)
@@ -145,7 +145,7 @@ namespace LaunchDarkly.Sdk.Server.Integrations
                 client,
                 _existingClient != null,
                 _prefix,
-                context.Basic.Logger.SubLogger("DataStore.Consul")
+                context.Logger.SubLogger("DataStore.Consul")
                 );
         }
     }

--- a/src/LaunchDarkly.ServerSdk.Consul/ConsulDataStoreImpl.cs
+++ b/src/LaunchDarkly.ServerSdk.Consul/ConsulDataStoreImpl.cs
@@ -4,9 +4,9 @@ using System.Text;
 using System.Threading.Tasks;
 using Consul;
 using LaunchDarkly.Logging;
-using LaunchDarkly.Sdk.Server.Interfaces;
+using LaunchDarkly.Sdk.Server.Subsystems;
 
-using static LaunchDarkly.Sdk.Server.Interfaces.DataStoreTypes;
+using static LaunchDarkly.Sdk.Server.Subsystems.DataStoreTypes;
 
 namespace LaunchDarkly.Sdk.Server.Integrations
 {
@@ -31,7 +31,7 @@ namespace LaunchDarkly.Sdk.Server.Integrations
     /// happened to execute later than the Upsert; we are relying on the fact that normally the
     /// process that did the Init will also receive the new data shortly and do its own Upsert.</item>
     /// </list>
-    /// </summary>
+    /// </remarks>
     internal sealed class ConsulDataStoreImpl : IPersistentDataStoreAsync
     {   
         private readonly ConsulClient _client;

--- a/src/LaunchDarkly.ServerSdk.Consul/LaunchDarkly.ServerSdk.Consul.csproj
+++ b/src/LaunchDarkly.ServerSdk.Consul/LaunchDarkly.ServerSdk.Consul.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Version>2.0.0</Version>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <PackageId>LaunchDarkly.ServerSdk.Consul</PackageId>
     <AssemblyName>LaunchDarkly.ServerSdk.Consul</AssemblyName>
     <OutputType>Library</OutputType>
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Consul" Version="[0.7.2.6,]" />
-    <PackageReference Include="LaunchDarkly.ServerSdk" Version="[6.0.0,7.0.0)" />
+    <PackageReference Include="LaunchDarkly.ServerSdk" Version="7.0.0-alpha.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/LaunchDarkly.ServerSdk.Consul.Tests/ConsulDataStoreTest.cs
+++ b/test/LaunchDarkly.ServerSdk.Consul.Tests/ConsulDataStoreTest.cs
@@ -2,7 +2,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Consul;
 using LaunchDarkly.Logging;
-using LaunchDarkly.Sdk.Server.Interfaces;
+using LaunchDarkly.Sdk.Server.Subsystems;
 using LaunchDarkly.Sdk.Server.SharedTests.DataStore;
 using Xunit;
 using Xunit.Abstractions;
@@ -23,7 +23,7 @@ namespace LaunchDarkly.Sdk.Server.Integrations
 
         public ConsulDataStoreTest(ITestOutputHelper testOutput) : base(testOutput) { }
 
-        private IPersistentDataStoreAsyncFactory MakeStoreFactory(string prefix) =>
+        private IComponentConfigurer<IPersistentDataStoreAsync> MakeStoreFactory(string prefix) =>
             Consul.DataStore().Prefix(prefix);
 
         private async Task ClearAllData(string prefix)
@@ -46,10 +46,9 @@ namespace LaunchDarkly.Sdk.Server.Integrations
         {
             var logCapture = Logs.Capture();
             var logger = logCapture.Logger("BaseLoggerName"); // in real life, the SDK will provide its own base log name
-            var context = new LdClientContext(new BasicConfiguration("", false, logger),
-                LaunchDarkly.Sdk.Server.Configuration.Default(""));
+            var context = new LdClientContext("", null, null, null, logger, false, null);
             using (Consul.DataStore().Address("http://localhost:8500").Prefix("my-prefix")
-                .CreatePersistentDataStore(context))
+                .Build(context))
             {
                 Assert.Collection(logCapture.GetMessages(),
                     m =>

--- a/test/LaunchDarkly.ServerSdk.Consul.Tests/LaunchDarkly.ServerSdk.Consul.Tests.csproj
+++ b/test/LaunchDarkly.ServerSdk.Consul.Tests/LaunchDarkly.ServerSdk.Consul.Tests.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net462</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <RootNamespace>LaunchDarkly.Client.Integrations</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>


### PR DESCRIPTION
* Some SDK types were moved from `Interfaces` to `Subsystems`
* Some interfaces are now replaced by the generic `IComponentConfigurer<T>`
* Updated target framework compatibility

We're still using a very old version of the Consul client package; I'll update that in a separate PR.