### PR TITLE
update to stable version of Consul client

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This version of the library is built for the following targets:
 
 The .NET build tools should automatically load the most appropriate build of the library for whatever platform your application or library is targeted to.
 
+It has a dependency on version 1.6.1.1 of the [Consul client package](https://www.nuget.org/packages/Consul). If you are using a higher version of that package, you should install it explicitly as a dependency in your application to override this minimum version.
+
 ## Signing
 
 The published version of this assembly is digitally signed with Authenticode and [strong-named](https://docs.microsoft.com/en-us/dotnet/framework/app-domains/strong-named-assemblies). Building the code locally in the default Debug configuration does not use strong-naming and does not require a key file.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CircleCI](https://circleci.com/gh/launchdarkly/dotnet-server-sdk-consul.svg?style=shield)](https://circleci.com/gh/launchdarkly/dotnet-server-sdk-consul)
 [![Documentation](https://img.shields.io/static/v1?label=GitHub+Pages&message=API+reference&color=00add8)](https://launchdarkly.github.io/dotnet-server-sdk-consul)
 
-This library provides a Consul-backed persistence mechanism (data store) for the [LaunchDarkly server-side .NET SDK](https://github.com/launchdarkly/dotnet-server-sdk), replacing the default in-memory data store. It uses the open-source [Consul.NET](https://github.com/G-Research/consuldotnet) package.
+This library provides a Consul-backed persistence mechanism (data store) for the [LaunchDarkly server-side .NET SDK](https://github.com/launchdarkly/dotnet-server-sdk), replacing the default in-memory data store. It uses the open-source [Consul.NET](https://www.nuget.org/packages/Consul) package.
 
 For more information, see also: [Using a persistent data store](https://docs.launchdarkly.com/v2.0/docs/using-a-persistent-feature-store).
 
@@ -21,7 +21,7 @@ This version of the library is built for the following targets:
 
 The .NET build tools should automatically load the most appropriate build of the library for whatever platform your application or library is targeted to.
 
-It has a dependency on version 1.6.1.1 of the [Consul client package](https://www.nuget.org/packages/Consul). If you are using a higher version of that package, you should install it explicitly as a dependency in your application to override this minimum version.
+It has a dependency on version 1.6.1.1 of [Consul.NET](https://www.nuget.org/packages/Consul). If you are using a higher version of that package, you should install it explicitly as a dependency in your application to override this minimum version.
 
 ## Signing
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CircleCI](https://circleci.com/gh/launchdarkly/dotnet-server-sdk-consul.svg?style=shield)](https://circleci.com/gh/launchdarkly/dotnet-server-sdk-consul)
 [![Documentation](https://img.shields.io/static/v1?label=GitHub+Pages&message=API+reference&color=00add8)](https://launchdarkly.github.io/dotnet-server-sdk-consul)
 
-This library provides a Consul-backed persistence mechanism (data store) for the [LaunchDarkly server-side .NET SDK](https://github.com/launchdarkly/dotnet-server-sdk), replacing the default in-memory data store. It uses [this open-source Consul client library](https://github.com/PlayFab/consuldotnet).
+This library provides a Consul-backed persistence mechanism (data store) for the [LaunchDarkly server-side .NET SDK](https://github.com/launchdarkly/dotnet-server-sdk), replacing the default in-memory data store. It uses the open-source [Consul.NET](https://github.com/G-Research/consuldotnet) package.
 
 For more information, see also: [Using a persistent data store](https://docs.launchdarkly.com/v2.0/docs/using-a-persistent-feature-store).
 

--- a/src/LaunchDarkly.ServerSdk.Consul/Consul.cs
+++ b/src/LaunchDarkly.ServerSdk.Consul/Consul.cs
@@ -13,14 +13,30 @@ namespace LaunchDarkly.Sdk.Server.Integrations
         public static readonly string DefaultPrefix = "launchdarkly";
 
         /// <summary>
-        /// Returns a builder object for creating a Consul-backed data store.
+        /// Returns a builder object for creating a Consul-backed persistent data store.
         /// </summary>
         /// <remarks>
-        /// This object can be modified with <see cref="ConsulDataStoreBuilder"/> methods for any desired
-        /// custom Consul options. Then, pass it to <see cref="Components.PersistentDataStore(IComponentConfigurer{IPersistentDataStoreAsync})"/>
-        /// and set any desired caching options. Finally, pass the result to <see cref="ConfigurationBuilder.DataStore(IComponentConfigurer{IDataStore})"/>.
-        /// </remarks>
-        /// <example>
+        /// <para>
+        /// You can use methods of the builder to specify any non-default Consul options
+        /// you may want, before passing the builder to
+        /// <see cref="Components.PersistentDataStore(IComponentConfigurer{IPersistentDataStore})"/>.
+        /// In this example, the store is configured with only the host address:
+        /// </para>
+        /// <code>
+        ///     var config = Configuration.Builder("sdk-key")
+        ///         .DataStore(
+        ///             Components.PersistentDataStore(
+        ///                 Consul.DataStore().Address("http://my-consul-host:8500")
+        ///             )
+        ///         )
+        ///         .Build();
+        /// </code>
+        /// <para>
+        /// Note that the SDK also has its own options related to data storage that are configured
+        /// at a different level, because they are independent of what database is being used. For
+        /// instance, the builder returned by <see cref="Components.PersistentDataStore(IComponentConfigurer{IPersistentDataStore})"/>
+        /// has options for caching:
+        /// </para>
         /// <code>
         ///     var config = Configuration.Builder("sdk-key")
         ///         .DataStore(
@@ -30,7 +46,8 @@ namespace LaunchDarkly.Sdk.Server.Integrations
         ///         )
         ///         .Build();
         /// </code>
-        /// </example>
+        /// </remarks>
+        /// <returns>a data store configuration object</returns>
         public static ConsulDataStoreBuilder DataStore() =>
             new ConsulDataStoreBuilder();
     }

--- a/src/LaunchDarkly.ServerSdk.Consul/ConsulDataStoreBuilder.cs
+++ b/src/LaunchDarkly.ServerSdk.Consul/ConsulDataStoreBuilder.cs
@@ -39,7 +39,8 @@ namespace LaunchDarkly.Sdk.Server.Integrations
     ///         .Build();
     /// </code>
     /// </remarks>
-    public sealed class ConsulDataStoreBuilder : IComponentConfigurer<IPersistentDataStoreAsync>
+    public sealed class ConsulDataStoreBuilder : IComponentConfigurer<IPersistentDataStoreAsync>,
+        IDiagnosticDescription
     {
         private ConsulClient _existingClient;
         private List<Action<ConsulClientConfiguration>> _configActions = new List<Action<ConsulClientConfiguration>>();
@@ -148,5 +149,9 @@ namespace LaunchDarkly.Sdk.Server.Integrations
                 context.Logger.SubLogger("DataStore.Consul")
                 );
         }
+
+        /// <inheritdoc/>
+        public LdValue DescribeConfiguration(LdClientContext context) =>
+            LdValue.Of("Consul");
     }
 }

--- a/src/LaunchDarkly.ServerSdk.Consul/LaunchDarkly.ServerSdk.Consul.csproj
+++ b/src/LaunchDarkly.ServerSdk.Consul/LaunchDarkly.ServerSdk.Consul.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Consul" Version="[0.7.2.6,]" />
+    <PackageReference Include="Consul" Version="[1.6.1.1,]" />
     <PackageReference Include="LaunchDarkly.ServerSdk" Version="7.0.0-alpha.3" />
   </ItemGroup>
 


### PR DESCRIPTION
When we originally implemented this integration, the only Consul client for .NET was a third-party one that had not been maintained for a long time and had a pre-1.0 version. The project has since been taken over by another maintainer (and has a new GitHub project, although the NuGet package name is unchanged) and is being actively maintained. This PR updates our dependency to the lowest compatible 1.x version.