### PR TITLE
update to stable version of Consul client (and drop .NET Framework 4.5.x)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,5 +35,5 @@ jobs:
           command: consul agent -dev
           background: true
       - run: dotnet restore
-      - run: dotnet build src/LaunchDarkly.ServerSdk.Consul -f net452
-      - run: dotnet test test/LaunchDarkly.ServerSdk.Consul.Tests -f net452
+      - run: dotnet build src/LaunchDarkly.ServerSdk.Consul -f net461
+      - run: dotnet test test/LaunchDarkly.ServerSdk.Consul.Tests -f net461

--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -6,7 +6,9 @@ publications:
 
 branches:
   - name: main
-    description: 2.x - for SDK 6+
+    description: 3.x - for SDK 6+, with new Consul client
+  - name: 2.x
+    description: for SDK 6+, with old Consul client
   - name: 1.x
     description: for SDK 5.x
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CircleCI](https://circleci.com/gh/launchdarkly/dotnet-server-sdk-consul.svg?style=shield)](https://circleci.com/gh/launchdarkly/dotnet-server-sdk-consul)
 [![Documentation](https://img.shields.io/static/v1?label=GitHub+Pages&message=API+reference&color=00add8)](https://launchdarkly.github.io/dotnet-server-sdk-consul)
 
-This library provides a Consul-backed persistence mechanism (data store) for the [LaunchDarkly server-side .NET SDK](https://github.com/launchdarkly/dotnet-server-sdk), replacing the default in-memory data store. It uses [this open-source Consul client library](https://github.com/PlayFab/consuldotnet).
+This library provides a Consul-backed persistence mechanism (data store) for the [LaunchDarkly server-side .NET SDK](https://github.com/launchdarkly/dotnet-server-sdk), replacing the default in-memory data store. It uses the open-source [Consul.NET](https://www.nuget.org/packages/Consul) package.
 
 For more information, see also: [Using Consul as a persistent feature store](https://docs.launchdarkly.com/sdk/features/storing-data/consul#net-server-side).
 
@@ -16,10 +16,12 @@ For full usage details and examples, see the [API reference](launchdarkly.github
 
 This version of the library is built for the following targets:
 
-* .NET Framework 4.5.2: runs on .NET Framework 4.5.x and above.
-* .NET Standard 2.0: runs on .NET Core 2.x and 3.x, or .NET 5, in an application; or within a library that is targeted to .NET Standard 2.x or .NET 5.
+* .NET Framework 4.6.1: runs on .NET Framework 4.6.1 and above.
+* .NET Standard 2.0: runs on .NET Core 2.x and 3.x, or .NET 5+, in an application; or within a library that is targeted to .NET Standard 2.x or .NET 5+.
 
 The .NET build tools should automatically load the most appropriate build of the library for whatever platform your application or library is targeted to.
+
+It has a dependency on version 1.6.1.1 of [Consul.NET](https://www.nuget.org/packages/Consul). If you are using a higher version of that package, you should install it explicitly as a dependency in your application to override this minimum version.
 
 ## Signing
 

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/LaunchDarkly.ServerSdk.SharedTests.csproj
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/LaunchDarkly.ServerSdk.SharedTests.csproj
@@ -3,7 +3,7 @@
     <Version>2.0.0-alpha.2</Version>
     <PackageId>LaunchDarkly.ServerSdk.SharedTests</PackageId>
     <AssemblyName>LaunchDarkly.ServerSdk.SharedTests</AssemblyName>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <OutputType>Library</OutputType>
     <Description>LaunchDarkly .NET Shared Tests</Description>
     <Company>LaunchDarkly</Company>

--- a/src/LaunchDarkly.ServerSdk.Consul/LaunchDarkly.ServerSdk.Consul.csproj
+++ b/src/LaunchDarkly.ServerSdk.Consul/LaunchDarkly.ServerSdk.Consul.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Version>2.0.0</Version>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <PackageId>LaunchDarkly.ServerSdk.Consul</PackageId>
     <AssemblyName>LaunchDarkly.ServerSdk.Consul</AssemblyName>
     <OutputType>Library</OutputType>

--- a/src/LaunchDarkly.ServerSdk.Consul/LaunchDarkly.ServerSdk.Consul.csproj
+++ b/src/LaunchDarkly.ServerSdk.Consul/LaunchDarkly.ServerSdk.Consul.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Consul" Version="[0.7.2.6,]" />
+    <PackageReference Include="Consul" Version="[1.6.1.1,]" />
     <PackageReference Include="LaunchDarkly.ServerSdk" Version="[6.0.0,7.0.0)" />
   </ItemGroup>
 

--- a/test/LaunchDarkly.ServerSdk.Consul.Tests/LaunchDarkly.ServerSdk.Consul.Tests.csproj
+++ b/test/LaunchDarkly.ServerSdk.Consul.Tests/LaunchDarkly.ServerSdk.Consul.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <RootNamespace>LaunchDarkly.Client.Integrations</RootNamespace>


### PR DESCRIPTION
This is a backport of https://github.com/launchdarkly/dotnet-server-sdk-consul/pull/12 to the main line, so that we can release a 3.0 major version that is for the current SDK _and_ references the newer Consul client. The future release corresponding to the next SDK major version will now be 4.0 rather than 3.0.

As part of this change, I dropped compatibility with .NET Framework 4.5.x because it's EOL and is no longer supported at all by the Consul client. I bumped the lower bound to 4.6.1 even though 4.6.1 is also EOL, just because this is for users of the 6.x .NET SDK who might not have all gotten away from 4.6.1 yet.